### PR TITLE
add adID

### DIFF
--- a/src/app/components/HLSPlayer.tsx
+++ b/src/app/components/HLSPlayer.tsx
@@ -18,6 +18,7 @@ import Link from "next/link";
 import Image from "next/image";
 
 export interface Ad {
+  adID: string;
   adURL: string;
   adVideoURL: string;
   adTiming: number;
@@ -254,7 +255,7 @@ const HLSPlayer: React.FC<HLSPlayerProps> = ({
             watchCountAdVideo({
               variables: {
                 input: {
-                  adID: ads[currentTime2].adVideoURL,
+                  adID: ads[currentTime2].adID,
                   city: "",
                   clientID: localStorage.getItem("clientID") as string,
                   country: "",

--- a/src/app/video/[id]/Video.tsx
+++ b/src/app/video/[id]/Video.tsx
@@ -105,6 +105,7 @@ export default function VideoPage({ params }: { params: { id: string } }) {
     let count = 0;
     for (const adData of adDatas.adVideo) {
       ads.push({
+        adID: adData.adID,
         adVideoURL: adData.videoURL,
         adURL: adData.adURL,
         adTiming: 300 * count,


### PR DESCRIPTION
このプル リクエストには、広告をより適切に追跡するための新しい `adID` フィールドを組み込むための `HLSPlayer` および `VideoPage` コンポーネントの更新が含まれています。

主な変更点:

* [`src/app/components/HLSPlayer.tsx`](diffhunk://#diff-becf9251f8794197d0308401fd053c1ada350e241f6b5ad6b36c4c6c25c41349R21): 各広告を一意に識別するために、`adID` を `Ad` インターフェースに追加しました。
* [`src/app/components/HLSPlayer.tsx`](diffhunk://#diff-becf9251f8794197d0308401fd053c1ada350e241f6b5ad6b36c4c6c25c41349L257-R258): `watchCountAdVideo` 関数を更新し、トラッキングに `adVideoURL` ではなく新しい `adID` を使用するようにしました。
* `src/app/video/[id]/Video.tsx`: 各広告に一意の識別子があることを確認するために、`adID` を `ads` 配列に追加しました。 ([src/app/video/[id]/Video.tsxR108](diffhunk://#diff-be8968f7be7e0e595455920f540a3c697e924615b4b09033c7c8ee66d66d80dcR108))